### PR TITLE
Use latest turbine schemas.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,34 +1,34 @@
 {
   "name": "@adobe/reactor-validator",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@adobe/reactor-turbine-schemas": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@adobe/reactor-turbine-schemas/-/reactor-turbine-schemas-8.2.0.tgz",
-      "integrity": "sha512-hBmzLMhNwrATt3nOT5O8TaMtXARVFtLNfnNdRimMPQq/oyGNHemXrAKXPmyY3idiYpPJU53HlcH+adpEUWQuFA=="
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@adobe/reactor-turbine-schemas/-/reactor-turbine-schemas-9.1.0.tgz",
+      "integrity": "sha512-09hCUywqGVHrP03xVVPhL5fXOMUd/r8Xh5Rp2WDfExDqDSm9WRuraKnAXMGZZMOOD3uzQh7y3B/5jcqFt1vCKA=="
     },
     "ajv": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
-      "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
+      "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
       "requires": {
-        "fast-deep-equal": "^2.0.1",
+        "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.1"
+        "uri-js": "^4.2.2"
       }
     },
     "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "json-schema-traverse": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/reactor-validator",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Validates an Launch extension package.",
   "main": "lib/index.js",
   "bin": {
@@ -17,7 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@adobe/reactor-turbine-schemas": "^8.2.0",
-    "ajv": "^6.5.1"
+    "@adobe/reactor-turbine-schemas": "^9.1.0",
+    "ajv": "^6.12.2"
   }
 }


### PR DESCRIPTION
For developing server extensions I need a higher version that 8.5.1.

It seems we increased the turbine-schemas version to v9 when we did the work for actions sequencing. I think nothing will break.