### PR TITLE
only run npm publish during new draft release

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,8 +4,8 @@
 name: Node.js Package
 
 on:
-  push:
-    branches: [master]
+  release:
+    types: [published]
 
 jobs:
   publish-npm:


### PR DESCRIPTION
If we did a release on every push of master, we'd be doing it too often.